### PR TITLE
fix(librespot): bump Go to 1.25 and add flac-dev build dependency

### DIFF
--- a/plugins/librespot/Dockerfile.template
+++ b/plugins/librespot/Dockerfile.template
@@ -1,7 +1,7 @@
 # ----------------------
 # Stage 1: Build go-librespot
 # ----------------------
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Build dependencies only
 RUN apk add --no-cache \
@@ -10,7 +10,8 @@ RUN apk add --no-cache \
     pkgconf \
     alsa-lib-dev \
     libogg-dev \
-    libvorbis-dev
+    libvorbis-dev \
+    flac-dev
 
 # Clone and build
 RUN git clone https://github.com/devgianlu/go-librespot.git /go-librespot


### PR DESCRIPTION
## Problem
- `go-librespot` now requires `go >= 1.25`, causing build failure with `golang:1.22-alpine`
- `flac-dev` is required by the go-librespot flac package at build time but was missing from the builder stage

## Changes
- Bumped builder base image from `golang:1.22-alpine` to `golang:1.25-alpine`
- Added `flac-dev` to the `apk add` dependencies in the builder stage