### PR TITLE
fix(ci): pass secrets to Flowzone with inherit

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -9,5 +9,4 @@ jobs:
   flowzone:
     name: Flowzone
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
-    secrets:
-      FLOWZONE_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
Flowzone updated to require FLOWZONE_APP_PRIVATE_KEY, GH_APP_PRIVATE_KEY, or FLOWZONE_TOKEN. Switching to secrets: inherit passes all repo secrets automatically and avoids future breakage if Flowzone renames secrets again.

Change-type: patch