### PR TITLE
fix(ci): use pull_request_target for Dependabot to access secrets

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -18,8 +18,8 @@ jobs:
   flowzone:
     name: Flowzone
     if: |
-      (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') ||
-      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+      (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'dependabot/')) ||
+      (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'dependabot/'))
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
     secrets:
       FLOWZONE_APP_PRIVATE_KEY: ${{ secrets.FLOWZONE_APP_PRIVATE_KEY }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -5,9 +5,21 @@ on:
     branches:
       - "main"
       - "master"
+  # pull_request_target runs in the base-branch context and has full access to
+  # Actions secrets, which can be forwarded to reusable workflows. Used
+  # exclusively for Dependabot PRs because GitHub blocks Dependabot secrets
+  # from reaching reusable workflows via the pull_request event.
+  pull_request_target:
+    types: [opened, synchronize, closed]
+    branches:
+      - "main"
+      - "master"
 jobs:
   flowzone:
     name: Flowzone
+    if: |
+      (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') ||
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
     secrets:
       FLOWZONE_APP_PRIVATE_KEY: ${{ secrets.FLOWZONE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- GitHub blocks Dependabot secrets from being forwarded to reusable workflows via the `pull_request` event — this is why Flowzone always fails on Dependabot PRs
- `pull_request_target` runs in the base-branch context with full Actions-secret access, which does reach reusable workflows
- Job condition routes human PRs through `pull_request` (unchanged) and Dependabot PRs through `pull_request_target`

## Test plan
- [ ] This PR passes Flowzone via the `pull_request` path
- [ ] After merge, ask Dependabot to rebase PR #24 and confirm Flowzone passes via `pull_request_target`

🤖 Generated with [Claude Code](https://claude.com/claude-code)