### PR TITLE
fix(ci): restore clean flowzone.yml

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -5,21 +5,9 @@ on:
     branches:
       - "main"
       - "master"
-  # pull_request_target runs in the base-branch context and has full access to
-  # Actions secrets, which can be forwarded to reusable workflows. Used
-  # exclusively for Dependabot PRs because GitHub blocks Dependabot secrets
-  # from reaching reusable workflows via the pull_request event.
-  pull_request_target:
-    types: [opened, synchronize, closed]
-    branches:
-      - "main"
-      - "master"
 jobs:
   flowzone:
     name: Flowzone
-    if: |
-      (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'dependabot/')) ||
-      (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'dependabot/'))
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
     secrets:
       FLOWZONE_APP_PRIVATE_KEY: ${{ secrets.FLOWZONE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Removes pull_request_target and the if condition — both broke Dependabot. Flowzone rejects pull_request_target internally; the FLOWZONE_TOKEN Dependabot secret (PAT) handles access.